### PR TITLE
Add a :session_encrypted option to use Rack::Session::EncryptedCookie.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ HTTP cookie-based sessions.
     `session_expire` -> The number of seconds from now the cookie will be valid
     `session_secret` -> A secret key that is used to check the integrity of
                         session data
+    `session_encrypted` -> Set to `true` to use Rack::Session::EncryptedCookie.
+                          Note that `session_secret` must also be a (random)
+                          string > 32 chars. See below.
+
+***Rack::Session::EncryptedCookie** is implemented through the `encrypted_cookie` gem, which provides 256-bit-AES-encrypted, tamper-proof cookies for Rack. Your `:session_secret` must be at least 32 bytes long and should be really random. Don't use a password or passphrase, generate something random. E.g. run this in a terminal and paste the output into your script:
+
+    $ ruby -rsecurerandom -e "puts SecureRandom.hex(32)"
 
 ## Helper Methods
 
@@ -47,7 +54,8 @@ require 'sinatra'
 require 'sinatra/session'
 
 set :session_fail, '/login'
-set :session_secret, 'So0perSeKr3t!'
+set :session_secret, 'So0perSeKr3t!So0perSeKr3t!So0perSeKr3t!'
+set :session_encrypted, true
 
 get '/' do
   session!

--- a/sinatra-session.gemspec
+++ b/sinatra-session.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'sinatra-session'
-  s.version = '1.0.1'
+  s.version = '1.1.0'
   s.date = Time.now.strftime('%Y-%m-%d')
 
   s.summary = 'Simple, secure sessions for Sinatra'
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
     %w< sinatra-session.gemspec Rakefile README.md >
 
   s.add_dependency('sinatra', '>= 1.0')
+  s.add_dependency('encrypted_cookie', '>= 0.0.4')
   s.add_development_dependency('rake')
 
   s.rdoc_options = %w< --line-numbers --inline-source --title Sinatra::Session --main Sinatra::Session >


### PR DESCRIPTION
Implemented https://github.com/cvonkleist/encrypted_cookie as an option.
This also seems to fix the issue with settings not used, cf. #4.
